### PR TITLE
fix: resume link href

### DIFF
--- a/src/components/application/modal/mc/mc.component.jsx
+++ b/src/components/application/modal/mc/mc.component.jsx
@@ -63,11 +63,11 @@ const Modalmc = ({ handleClose, data, style }) => {
           </div>
         </div>
         <div className="bottom-button">
-          <button href={data?.resumelink} className="cancel-button" onClick={handleClose}>
+          <button className="cancel-button" onClick={handleClose}>
             Close
           </button>
           <button className="confirm-button">
-            <Link to={data?.resumelinkLink} target="_blank" rel="noreferrer">
+            <Link to={data?.resumeLink} target="_blank" rel="noreferrer">
               Resume
             </Link>
           </button>


### PR DESCRIPTION
Resume link href was wrong, resume not opening for candidate. 
file changed :mc.component.jsx:
 line number: 70 {data?.resumeLink}

Also removed href from button on line 66, It was redundant.